### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/GameData/BoulderCo/CityLights/CityLights.version
+++ b/GameData/BoulderCo/CityLights/CityLights.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "EnvironmentalVisualEffects - CityLights",
+  "URL": "https://raw.githubusercontent.com/rbray89/EnvironmentalVisualEnhancements/master/GameData/BoulderCo/CityLights/CityLights.version",
+  "VERSION": {
+    "MAJOR": 7,
+    "MINOR": 3,
+    "PATCH": "LR"
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}

--- a/GameData/BoulderCo/Clouds/Clouds.version
+++ b/GameData/BoulderCo/Clouds/Clouds.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "EnvironmentalVisualEffects - Clouds",
+  "URL": "https://raw.githubusercontent.com/rbray89/EnvironmentalVisualEnhancements/master/GameData/BoulderCo/Clouds/Clouds.version",
+  "VERSION": {
+    "MAJOR": 7,
+    "MINOR": 3,
+    "PATCH": "LR"
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}

--- a/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEffects.version
+++ b/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEffects.version
@@ -1,0 +1,13 @@
+{
+  "NAME": "EnvironmentalVisualEffects",
+  "URL": "https://raw.githubusercontent.com/rbray89/EnvironmentalVisualEnhancements/master/GameData/EnvironmentalVisualEnhancements/EnvironmentalVisualEnhancements.version",
+  "VERSION": {
+    "MAJOR": 7,
+    "MINOR": 3
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}


### PR DESCRIPTION
Dearest rbray et al,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note**: I wasn't sure whether clouds and citylights are considered versioned or not. So I opted to put a version file in there with an indicator for the Low-res or not in the PATCH field. If that doesn't work with your vision of the project I think it's perfectly okay to delete these version files (it doesn't actually matter where they live or how many there are in a project)

Sidenote: Thank you for making these projects. KSP just isn't the same without beautiful clouds and city lights. 
